### PR TITLE
Hide native scrollbar properly when zooming

### DIFF
--- a/simple-scrollbar.css
+++ b/simple-scrollbar.css
@@ -12,7 +12,6 @@
   width: 100%;
   padding: 0 32px 0 0;
   position: relative;
-  right: -18px;
   overflow: auto;
   box-sizing: border-box;
 }

--- a/simple-scrollbar.js
+++ b/simple-scrollbar.js
@@ -109,7 +109,8 @@
     w.addEventListener("resize", resizeRight);
 
     function resizeRight() {
-      sheet.innerHTML = ".ss-content{right: " + -18 / w.devicePixelRatio + "px;}";
+      var dpr = w.devicePixelRatio || w.screen.deviceXDPI / w.screen.logicalXDPI || 1
+      sheet.innerHTML = ".ss-content{right: " + -18 / dpr + "px;}";
     }
   }
 

--- a/simple-scrollbar.js
+++ b/simple-scrollbar.js
@@ -102,7 +102,21 @@
     }
   }
 
-  d.addEventListener('DOMContentLoaded', initAll);
+  function handleResize() {
+    var sheet = d.createElement("style");
+    resizeRight();
+    d.body.appendChild(sheet);
+    w.addEventListener("resize", resizeRight);
+
+    function resizeRight() {
+      sheet.innerHTML = ".ss-content{right: " + -18 / w.devicePixelRatio + "px;}";
+    }
+  }
+
+  d.addEventListener('DOMContentLoaded', function() {
+    initAll();
+    handleResize();
+  });
   ss.initEl = initEl;
   ss.initAll = initAll;
 

--- a/simple-scrollbar.js
+++ b/simple-scrollbar.js
@@ -103,14 +103,14 @@
   }
 
   function handleResize() {
-    var sheet = d.createElement("style");
+    var sheet = d.createElement('style');
     resizeRight();
     d.body.appendChild(sheet);
-    w.addEventListener("resize", resizeRight);
+    w.addEventListener('resize', resizeRight);
 
     function resizeRight() {
       var dpr = w.devicePixelRatio || w.screen.deviceXDPI / w.screen.logicalXDPI || 1
-      sheet.innerHTML = ".ss-content{right: " + -18 / dpr + "px;}";
+      sheet.innerHTML = '.ss-content{right: ' + -18 / dpr + 'px;}';
     }
   }
 


### PR DESCRIPTION
Currently the width of native scrollbars is hard coded to 18px in the css file. However when zooming browsers do not resize the scrollbars causing them to leak when zooming out. This fixes that by taking the devicePixelRatio into account.