### PR TITLE
Replaced hasOwnProperty on taget object with Object.prototype.hasOwnProperty.call. Just a Better guard since Object.create(null) is possible

### DIFF
--- a/simple-scrollbar.js
+++ b/simple-scrollbar.js
@@ -2,7 +2,7 @@
   var raf = w.requestAnimationFrame || w.setImmediate || function(c) { return setTimeout(c, 0); };
 
   function initEl(el) {
-    if (el.hasOwnProperty('data-simple-scrollbar')) return;
+    if (Object.prototype.hasOwnProperty.call(el, 'data-simple-scrollbar')) return;
     Object.defineProperty(el, 'data-simple-scrollbar', new SimpleScrollbar(el));
   }
 


### PR DESCRIPTION

@buzinas 
https://eslint.org/docs/rules/no-prototype-builtins