### PR TITLE
Add active state to scrollbar

### DIFF
--- a/simple-scrollbar.css
+++ b/simple-scrollbar.css
@@ -37,7 +37,9 @@
   display: none;
 }
 
-.ss-container:hover .ss-scroll {
+
+.ss-container:hover .ss-scroll,
+.ss-container:active .ss-scroll {
   opacity: 1;
 }
 

--- a/simple-scrollbar.css
+++ b/simple-scrollbar.css
@@ -37,7 +37,6 @@
   display: none;
 }
 
-
 .ss-container:hover .ss-scroll,
 .ss-container:active .ss-scroll {
   opacity: 1;


### PR DESCRIPTION
If you click and hold the scrollbar to drag, scrolling continues to work even if your mouse leaves the `.ss-container` ...which is the correct behavior, but the scrollbar fades out; this change enables the scrollbar to remain visible.

**Broken:**

![broken](https://user-images.githubusercontent.com/2044842/32786286-cc13fda8-c953-11e7-8dbf-710abedd585b.gif)

**Fixed:**

![fix](https://user-images.githubusercontent.com/2044842/32786292-d0a24302-c953-11e7-86a2-5f75db681ffb.gif)
