### PR TITLE
Fix scrollbar being incorrectly positioned when first shown

### DIFF
--- a/simple-scrollbar.js
+++ b/simple-scrollbar.js
@@ -82,8 +82,8 @@
     this.target.classList.add('ss-container');
 
     var css = w.getComputedStyle(el);
-  	if (css['height'] === '0px' && css['max-height'] !== '0px') {
-    	el.style.height = css['max-height'];
+    if (css['height'] === '0px' && css['max-height'] !== '0px') {
+      el.style.height = css['max-height'];
     }
   }
 
@@ -96,16 +96,16 @@
       this.scrollRatio = ownHeight / totalHeight;
 
       var isRtl = _this.direction === 'rtl';
-      var right = isRtl ?
-        (_this.target.clientWidth - _this.bar.clientWidth + 18) :
-        (_this.target.clientWidth - _this.bar.clientWidth) * -1;
 
       raf(function() {
         // Hide scrollbar if no scrolling is possible
         if(_this.scrollRatio >= 1) {
-          _this.bar.classList.add('ss-hidden')
+          _this.bar.classList.add('ss-hidden');
         } else {
-          _this.bar.classList.remove('ss-hidden')
+          _this.bar.classList.remove('ss-hidden');
+          var right = isRtl ?
+            (_this.target.clientWidth - _this.bar.clientWidth + 18) :
+            (_this.target.clientWidth - _this.bar.clientWidth) * -1;
           _this.bar.style.cssText = 'height:' + Math.max(_this.scrollRatio * 100, 10) + '%; top:' + (_this.el.scrollTop / totalHeight ) * 100 + '%;right:' + right + 'px;';
         }
       });


### PR DESCRIPTION
Previously, if the scrollbar were initially hidden (due to having a small amount of content) and then enough content was added that the scrollbar became visible, the scrollbar would be a few pixels too far to the right. This fixes that issue by computing the 'right' property after the 'ss-hidden' class is removed.