### PR TITLE
Fix to rebuild scrollbar with ajax or other callbacks

### DIFF
--- a/simple-scrollbar.js
+++ b/simple-scrollbar.js
@@ -8,8 +8,7 @@
   var raf = w.requestAnimationFrame || w.setImmediate || function(c) { return setTimeout(c, 0); };
 
   function initEl(el) {
-    if (Object.prototype.hasOwnProperty.call(el, 'data-simple-scrollbar')) return;
-    Object.defineProperty(el, 'data-simple-scrollbar', { value: new SimpleScrollbar(el) });
+    Object.defineProperty(el, 'data-simple-scrollbar', { value: new SimpleScrollbar(el), configurable: true });
   }
 
   // Mouse drag handler


### PR DESCRIPTION
I tried to use you cool & lightweight scrollbal in my solution, ex xhr:
```
..................
for (var i = 0; i < data.features.length; i++) {
			var li = createLI(data.features[i]);
			ul.appendChild(li);
		}
		document.querySelector('#lists').innerHTML = '';
		document.querySelector('#lists').appendChild(ul);
		SimpleScrollbar.initEl(document.querySelector('#lists'));
		ul.childNodes.forEach(function(el,index){
			el.onclick = function(){
				//console.log(el,i)
				console.log(index)
				clickOnLI(el,objectManager);
			}
		})
............
```
But its do not want to refresh scroll. I did this fix, If it useful - it will be cool